### PR TITLE
[minor] add browser config using browserify transform

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,1 @@
+module.exports = require('feathers-configuration')()()

--- a/createStore.js
+++ b/createStore.js
@@ -3,13 +3,13 @@ const { createStore: Store, applyMiddleware, compose } = require('redux')
 const { createEpicMiddleware, combineEpics } = require('redux-observable')
 const { ConnectedRouter, routerMiddleware } = require('react-router-redux')
 const { concat: concatUpdaters } = require('redux-fp')
-
 const { createLogger } = require('redux-logger')
 
 module.exports = createStore
 
 function createStore (options) {
   const {
+    state,
     updater,
     epic,
     middlewares = [],
@@ -29,7 +29,7 @@ function createStore (options) {
   )
 
   const reducer = updaterToReducer(updater)
-  const store = Store(reducer, enhancer)
+  const store = Store(reducer, state, enhancer)
 
   return store
 }

--- a/entry.js
+++ b/entry.js
@@ -7,6 +7,9 @@ const createBrowserHistory = require('history/createBrowserHistory').default
 const h = require('react-hyperscript')
 const merge = require('ramda/src/merge')
 
+const config = require('dogstack/config')
+window.config = config
+
 const Root = require('dogstack/Root')
 const createStore = require('dogstack/createStore')
 const { createStyleRenderer } = require('dogstack/createStyle')
@@ -20,15 +23,19 @@ const routes = getDefaultExport(require('./routes'))
 const Layout = getDefaultExport(require('./layout'))
 
 document.addEventListener('DOMContentLoaded', () => {
+  const state = { config }
   const history = createBrowserHistory()
   const client = createClient(clientOptions)
+  window.client = client
 
   const store = createStore(
     merge(
-      { history, client },
+      { state, history, client },
       storeOptions
     )
   )
+  window.store = store
+
   const styleTheme = styleOptions.theme
   const styleRenderer = createStyleRenderer(styleOptions)
 

--- a/lib/configify.js
+++ b/lib/configify.js
@@ -1,0 +1,20 @@
+const stringToStream = require('string-to-stream')
+const staticModule = require('static-module')
+const Config = require('feathers-configuration')
+
+module.exports = Configify
+
+function Configify (filename, options) {
+  return staticModule({
+    'feathers-configuration': function () {
+      const getConfig = Config()
+      const config = getConfig() || {}
+      const browserConfig = config.browser || {}
+      return stringToStream(
+        'function () { return ' +
+          JSON.stringify(browserConfig) +
+        ' }'
+      )
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dogstack",
-  "version": "0.3.0",
+  "version": "0.4.0-pre.6",
   "description": "a popular-choice grab-bag framework for teams working on production web apps",
   "main": "index.js",
   "browser": "browser.js",
@@ -39,7 +39,8 @@
   "homepage": "https://dogstack.js.org",
   "browserify": {
     "transform": [
-      "es2040"
+      "es2040",
+      "./lib/configify"
     ]
   },
   "dependencies": {
@@ -88,6 +89,8 @@
     "socket.io-client": "^2.0.1",
     "standard": "^10.0.2",
     "standard-engine": "^7.0.0",
+    "static-module": "^1.3.2",
+    "string-to-stream": "^1.1.0",
     "uify-server": "^1.1.3",
     "uws": "^0.14.5",
     "yargs": "^7.1.0"


### PR DESCRIPTION
closes https://github.com/root-systems/dogstack/pull/68

- browser config is config at `browser` key
- add `dogstack/config` entry to receive config object
- attach `config`, `client`, and `store` to `window`